### PR TITLE
fix: add back-to-home arrow on about page

### DIFF
--- a/CODE_OF_CONDUCT.MD
+++ b/CODE_OF_CONDUCT.MD
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and
+will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+****contato.nahoradamissa@gmail.com****.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/sobre-nos.html
+++ b/sobre-nos.html
@@ -45,8 +45,16 @@
     <meta property="og:description" content="Saiba mais sobre o site Na Hora da Missa e sua missão de ajudar os fiéis a encontrar horários de missas e leituras litúrgicas.">
 </head>
 <body class="bg-blue-900 dark:bg-blue-900 bg-pattern">
+
     <!-- Header -->
     <header class="header-bg text-white py-12 text-center relative overflow-hidden">
+        <!-- Botão Voltar (Início) -->
+        <a href="index.html" 
+           class="absolute top-4 left-4 sm:top-6 sm:left-6 text-yellow-300 hover:text-yellow-400 text-3xl transition-colors z-20"
+           aria-label="Voltar para Início">
+          <i class="fas fa-arrow-left"></i>
+        </a>
+        <!-- Botão Voltar (Fim) -->
         <!-- Efeito de luz dourada -->
         <div class="absolute inset-0 bg-gradient-to-r from-yellow-400 to-yellow-600 opacity-20 mix-blend-overlay"></div>
         <h1 class="font-bold mb-4 mt-4 title-font text-5xl relative z-10">Sobre o Na Hora da Missa</h1>


### PR DESCRIPTION
Hi!

This PR adds a 'Back to Home' arrow icon to the top-left corner of the `sobre-nos.html` page.

This is a small "UI/UX polish" (as welcomed in the `README.md`) to make it easier for users to navigate back to the main page.

I've followed the `CONTRIBUTING.MD` guidelines for the commit message format. Thanks!

---

### Screenshot of the fix:

<img width="1354" height="633" alt="Screenshot 2025-10-27 131551" src="https://github.com/user-attachments/assets/21ce1a43-0264-4690-8a63-9d7f43d8d273" />
