### PR TITLE
fix: Clarify 'About Us' link text in footer

### DIFF
--- a/preparacao-para-missa.html
+++ b/preparacao-para-missa.html
@@ -132,7 +132,7 @@
     <footer class="bg-blue-900 text-white py-6 text-center mt-8 dark:bg-gray-800">
         <p class="text-sm">Atualizado diariamente. Este site não tem vínculo oficial com a Diocese.</p>
         <p class="text-sm mt-2">Desenvolvido por <a href="https://github.com/mcruvinel" class="text-blue-300 hover:underline" target="_blank">mcruvinel</a></p>
-        <p class="text-sm mt-2">Quer saber mais sobre nós? Clique no botão ao lado <a href="sobre-nos.html" class="text-yellow-300 hover:underline" target="_blank">Sobre Nós</a></p>
+        <p class="text-sm mt-2">Quer saber mais sobre nós? <a href="sobre-nos.html" class="text-yellow-300 hover:underline" target="_blank">Clique aqui</a>.</p>
         <p class="text-sm mt-2"> Duvidas ou sugestões? Entre em contato: <a href="mailto:contato.nahoradamissa@gmail.com" class="text-blue-300 hover:underline">contato.nahoradamissa@gmail.com</a></p>
     </footer>
 


### PR DESCRIPTION
Hi!

This PR fixes the slightly confusing text "Clique no botão ao lado" (Click the button next to it) in the footer, as the element is actually a link, not a button.

I've updated the text to simply say "Clique aqui" (Click here), making it clearer for users.
The change was made in the `preparacao-para-missa.html` file.

This is a small UI/copy polish as welcomed in the README. Thanks!

---
### Before:

<img width="1350" height="639" alt="before" src="https://github.com/user-attachments/assets/4864a71b-079a-49c1-bf8e-0315fb0f0875" />


### After:


<img width="1352" height="632" alt="after" src="https://github.com/user-attachments/assets/afa67da3-ec21-45c8-9d98-a684f0ce3a88" />



---